### PR TITLE
feat: pull all bake targets by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
             org/repo:tag
 ```
 
-Pull bake image targets:
+Pull all bake image targets:
 
 ```yaml
 jobs:
@@ -35,9 +35,6 @@ jobs:
       - uses: depot/pull-action@v1
         with:
           build-id: ${{ steps.build.outputs.build-id }}
-          target: your-target
-          tags: |
-            org/repo:tag
 ```
 
 ## Inputs
@@ -47,7 +44,7 @@ jobs:
 | `build-id` | string   | **yes**  | The build ID to pull images for.                                                                           |
 | `platform` | string   | no       | The image platform to pull (defaults to the current platform).                                             |
 | `tags`     | list/CSV | no       | A list of tags to apply to the pulled image.                                                               |
-| `target`   | string   | no       | For a bake build specifies the specific target to pull.                                                    |
+| `targets`  | list/CSV | no       | Only pull specific bake targets rather than all.                                                           |
 | `token`    | string   | no       | The API token to use for authentication. This can be overridden by the `DEPOT_TOKEN` environment variable. |
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,6 @@ inputs:
     description: If set, will populate the `DEPOT_TOKEN` environment variable.
     default: ''
     required: false
-  target:
-    description: Specific bake target to pull.
-    default: ''
+  targets:
+    description: Pull specific bake targets rather than all.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -30521,7 +30521,7 @@ function getInputs() {
     buildID: core.getInput("build-id"),
     platform: core.getInput("platform"),
     tags: parseCSV(core.getInput("tags")),
-    target: core.getInput("target"),
+    targets: parseCSV(core.getInput("targets")),
     token: core.getInput("token") || process.env.DEPOT_TOKEN
   };
 }
@@ -32160,7 +32160,7 @@ async function pull(inputs) {
   const args = [
     ...flag("--platform", inputs.platform),
     ...flag("--tag", inputs.tags),
-    ...flag("--target", inputs.target)
+    ...flag("--target", inputs.targets)
   ];
   let token = inputs.token ?? process.env.DEPOT_TOKEN;
   const isOSSPullRequest = !token && github.context.eventName === "pull_request" && github.context.payload.repository?.private === false && github.context.payload.pull_request && github.context.payload.pull_request.head?.repo?.full_name !== github.context.payload.repository?.full_name;

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,7 +5,7 @@ export interface Inputs {
   buildID: string
   platform?: string
   tags: string[]
-  target?: string
+  targets: string[]
   token?: string
 }
 
@@ -14,7 +14,7 @@ export function getInputs(): Inputs {
     buildID: core.getInput('build-id'),
     platform: core.getInput('platform'),
     tags: parseCSV(core.getInput('tags')),
-    target: core.getInput('target'),
+    targets: parseCSV(core.getInput('targets')),
     token: core.getInput('token') || process.env.DEPOT_TOKEN,
   }
 }

--- a/src/depot.ts
+++ b/src/depot.ts
@@ -49,7 +49,7 @@ export async function pull(inputs: Inputs) {
   const args = [
     ...flag('--platform', inputs.platform),
     ...flag('--tag', inputs.tags),
-    ...flag('--target', inputs.target),
+    ...flag('--target', inputs.targets),
   ]
 
   let token = inputs.token ?? process.env.DEPOT_TOKEN


### PR DESCRIPTION
Previously, it was tricky to pull multiple bake targets. Now, the depot pull command will pull all bake targets by default.

If only a few targets should be pulled, the `targets` parameter can be used as a filter.